### PR TITLE
Add Swagger UI documentation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This Node.js project implements a simple REST API using the Express framework an
 * **Login** (`POST /login`) – Authenticate a user and return a signed JSON Web Token (JWT).
 * **Protected CRUD** (`/users`) – List, create, update, and delete user records. All `/users` endpoints require a valid JWT in the `Authorization` header using the `Bearer` scheme.
 * **View** (`GET /`) – Render a simple HTML page listing users using EJS.
+* **Docs** (`GET /docs`) – Interactive API documentation powered by Swagger UI.
 
 ## Usage
 
@@ -19,3 +20,4 @@ npm start
 ```
 
 The server listens on `http://localhost:3000`.
+API documentation is available at `http://localhost:3000/docs`.

--- a/app.js
+++ b/app.js
@@ -3,6 +3,8 @@ const path = require('path');
 const authRoutes = require('./routes/authRoutes');
 const userRoutes = require('./routes/userRoutes');
 const userModel = require('./models/userModel');
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./swagger.json');
 
 const app = express();
 
@@ -10,6 +12,8 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
 app.use(express.json());
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.use(authRoutes);
 app.use('/users', userRoutes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "ejs": "^3.1.9",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -957,6 +958,13 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4508,6 +4516,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.1.tgz",
+      "integrity": "sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "description": "A basic Node.js project demonstrating an MVC structure",
   "dependencies": {
     "ejs": "^3.1.9",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/routes.test.js
+++ b/routes.test.js
@@ -109,4 +109,10 @@ describe('API endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.text).toContain('<!DOCTYPE html>');
   });
+
+  test('GET /docs serves swagger ui', async () => {
+    const res = await request(app).get('/docs/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Swagger UI');
+  });
 });

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Node Project API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local server"
+    }
+  ],
+  "paths": {
+    "/register": {
+      "post": {
+        "summary": "Register a new user",
+        "responses": {
+          "200": { "description": "User registered successfully" }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "summary": "Login a user",
+        "responses": {
+          "200": { "description": "Login success" },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "summary": "List users",
+        "responses": {
+          "200": { "description": "A list of users" }
+        }
+      },
+      "post": {
+        "summary": "Create user",
+        "responses": {
+          "201": { "description": "User created" }
+        }
+      }
+    },
+    "/users/{id}": {
+      "put": {
+        "summary": "Update user",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "User updated" }
+        }
+      },
+      "delete": {
+        "summary": "Delete user",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "User deleted" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- serve interactive Swagger UI at `/docs` backed by a new OpenAPI spec
- document API endpoints in `swagger.json` and mention docs in README
- test `/docs` route to ensure documentation is accessible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689713f604e4832abea358e04d1c2332